### PR TITLE
Add benchmarks for the `Matrix class`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "extern/doxygen-awesome"]
 	path = extern/doxygen-awesome
 	url = https://github.com/jothepro/doxygen-awesome-css.git
+[submodule "extern/benchmark"]
+	path = extern/benchmark
+	url = https://github.com/sbaldu/benchmark.git

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+project(Benchmark LANGUAGES CXX)
+
+add_subdirectory(Matrix/)

--- a/benchmark/Matrix/CMakeLists.txt
+++ b/benchmark/Matrix/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set the C++ flags
+string(APPEND CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -g")
+
+# Set the folder for the executable
+set(EXECUTABLE_OUTPUT_PATH ../../)
+
+# Set base directory for serial data formats
+include_directories(../../src/serial/DataFormats)
+include_directories(..)
+
+# Compile
+add_executable(MatrixOperations.out ./MatrixOperations.cc)
+add_executable(MatrixConstruction.out ./MatrixConstruction.cc)

--- a/benchmark/Matrix/MatrixConstruction.cc
+++ b/benchmark/Matrix/MatrixConstruction.cc
@@ -1,0 +1,30 @@
+
+#include <algorithm>
+#include <random>
+
+#include "Matrix.hpp"
+
+#include "Bench.hpp"
+#include "RandomMatrix.hpp"
+
+using sb::Bench;
+
+int main() {
+  const int n_rows{1 << 9};
+  const int n_cols{1 << 9};
+
+  // create a vector of n_rows * n_cols random elements
+  std::vector<int> v(n_rows * n_cols);
+  std::ranges::for_each(v, [](int& x) { x = std::rand(); });
+
+  Bench<long long int> b(100);
+  std::cout << "Benchmarking first Matrix constructor\n";
+  b.benchmark([](const int rows, const int cols) -> void { Matrix<int> mat(rows, cols); }, n_rows, n_cols);
+  b.print();
+  std::cout << "Benchmarking second Matrix constructor\n";
+  b.benchmark([](const int rows, const int cols, const std::vector<int>& vec) -> void { Matrix<int> mat(rows, cols, vec); }, n_rows, n_cols, v);
+  b.print();
+  std::cout << "Benchmarking third Matrix constructor\n";
+  b.benchmark([](const std::vector<int>& vec) -> void { Matrix<int> mat(vec); }, v);
+  b.print();
+}

--- a/benchmark/Matrix/MatrixOperations.cc
+++ b/benchmark/Matrix/MatrixOperations.cc
@@ -1,0 +1,43 @@
+
+#include "Matrix.hpp"
+
+#include "Bench.hpp"
+#include "RandomMatrix.hpp"
+
+
+using sb::Bench;
+
+int main() {
+  const int n_rows{1 << 8};
+  const int n_cols{1 << 8};
+  Matrix<int> m1(n_rows, n_cols);
+  Matrix<int> m2(n_rows, n_cols);
+  random_matrix(m1);
+  random_matrix(m2);
+
+  Bench<long long int> b(100);
+  std::cout << "Benchmarking Matrix sum\n";
+  b.benchmark([](const Matrix<int>& m1, const Matrix<int>& m2) -> Matrix<int> { return m1 + m2; }, m1, m2);
+  b.print();
+  std::cout << "Benchmarking Matrix multiplication\n";
+  b.benchmark([](const Matrix<int>& m1, const Matrix<int>& m2) -> Matrix<int> { return m1 * m2; }, m1, m2);
+  b.print<sb::microseconds>();
+  std::cout << "Benchmarking Matrix scalar multiplication\n";
+  b.benchmark([](int constant, const Matrix<int>& m1) -> Matrix<int> { return constant * m1; }, 100, m1);
+  b.print();
+  std::cout << "Benchmarking Matrix increment\n";
+  b.benchmark([&m1](const Matrix<int>& m2) -> void { m1 += m2; }, m2);
+  b.print();
+  std::cout << "Benchmarking Matrix decrement\n";
+  b.benchmark([&m1](const Matrix<int>& m2) -> void { m1 -= m2; }, m2);
+  b.print();
+  std::cout << "Benchmarking Matrix scaling multiplication\n";
+  b.benchmark([&m1](int constant) -> void { m1 *= constant; }, 100);
+  b.print();
+  std::cout << "Benchmarking Matrix scaling division\n";
+  b.benchmark([&m1](int constant) -> void { m1 /= constant; }, 100);
+  b.print();
+  std::cout << "Benchmarking Matrix transposition\n";
+  b.benchmark([&m1]() -> void { m1.transpose(); });
+  b.print();
+}

--- a/benchmark/Matrix/RandomMatrix.hpp
+++ b/benchmark/Matrix/RandomMatrix.hpp
@@ -1,0 +1,16 @@
+
+#ifndef random_matrix_hpp
+#define random_matrix_hpp
+
+#include <random>
+
+#include "Matrix.hpp"
+
+template <typename T>
+void random_matrix(Matrix<T>& mat) {
+  for (int i{}; i < mat.size(); ++i) {
+    mat[i] = std::rand();
+  }
+}
+
+#endif


### PR DESCRIPTION
This PR:
* includes the `sbaldu/benchmark` tool as a submodule
* benchmarks the main functionalities of the `Matrix` class, in particular matrix construction and matrix operations (issue #10)

Note: in the future it might be useful to benchmark the whole process of costruction and training of the neural network, in order to identify possible bottlenecks